### PR TITLE
Update Docker base image from Python 3.9-slim to 3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 # Prevent Python from writing .pyc files and ensure logs flush immediately
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
# Update Docker base image from Python 3.9-slim to 3.13-slim

The current `python:3.9-slim` base image limits yt-dlp to version 2025.10.14, as newer releases have dropped support for Python 3.9. This outdated version of yt-dlp results in 403 Forbidden errors when attempting to download from Spotify.

Updating the base image to `python:3.13-slim` allows yt-dlp to install the latest version (2026.3.13), which resolves the 403 errors.

## Changes
- Updated `Dockerfile` base image from `python:3.9-slim` to `python:3.13-slim`