### PR TITLE
fix: embed album art and organize downloads by playlist folder

### DIFF
--- a/gui/views/spotify_view.py
+++ b/gui/views/spotify_view.py
@@ -616,6 +616,8 @@ class SpotifyView(QWidget):
                 track.get("artist", "").strip(),
                 track.get("track", "").strip(),
                 playlist_name,
+                album=track.get("album"),
+                album_art_url=track.get("album_art_url"),
             )
             QMessageBox.information(
                 self, "Added to Queue",

--- a/gui/views/welcome_view.py
+++ b/gui/views/welcome_view.py
@@ -559,5 +559,6 @@ class WelcomeView(QWidget):
                 artist=track_data['artist'],
                 track=track_data['track'],
                 album=track_data.get('album', ''),
-                playlist=track_data.get('playlist', '')
+                playlist=track_data.get('playlist', ''),
+                album_art_url=track_data.get('album_art_url', ''),
             )

--- a/gui/workers/download_queue.py
+++ b/gui/workers/download_queue.py
@@ -23,6 +23,8 @@ class QueueItem:
     id: str
     artist: str
     track: str
+    album: Optional[str] = None
+    album_art_url: Optional[str] = None
     playlist: Optional[str] = None
     status: DownloadStatus = DownloadStatus.PENDING
     progress: int = 0  # 0-100
@@ -94,12 +96,15 @@ class DownloadQueue(QObject):
         """Check if downloads are paused."""
         return self._is_paused
 
-    def add_track(self, artist: str, track: str, playlist: Optional[str] = None) -> QueueItem:
+    def add_track(self, artist: str, track: str, playlist: Optional[str] = None,
+                  album: Optional[str] = None, album_art_url: Optional[str] = None) -> QueueItem:
         """Add a single track to the queue."""
         item = QueueItem(
             id=str(uuid.uuid4()),
             artist=artist,
             track=track,
+            album=album,
+            album_art_url=album_art_url,
             playlist=playlist,
             status=DownloadStatus.PENDING,
             progress=0
@@ -109,9 +114,11 @@ class DownloadQueue(QObject):
         self.queue_updated.emit(self.pending_count)
         return item
 
-    def add_item(self, artist: str, track: str, album: str = "", playlist: str = "") -> QueueItem:
+    def add_item(self, artist: str, track: str, album: str = "", playlist: str = "",
+                 album_art_url: str = "") -> QueueItem:
         """Add a single item to the queue (alias for add_track with album support)."""
-        return self.add_track(artist, track, playlist or None)
+        return self.add_track(artist, track, playlist or None,
+                              album=album or None, album_art_url=album_art_url or None)
 
     def add_tracks(self, tracks: list, playlist: Optional[str] = None) -> List[QueueItem]:
         """
@@ -129,7 +136,12 @@ class DownloadQueue(QObject):
             artist = track.get("artist", "").strip()
             track_name = track.get("track", "").strip()
             if artist and track_name:
-                item = self.add_track(artist, track_name, playlist)
+                item = self.add_track(
+                    artist, track_name,
+                    playlist=track.get("playlist") or playlist,
+                    album=track.get("album"),
+                    album_art_url=track.get("album_art_url"),
+                )
                 items.append(item)
         return items
 

--- a/gui/workers/download_worker.py
+++ b/gui/workers/download_worker.py
@@ -127,6 +127,12 @@ class DownloadWorker(QThread):
                 base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
             output_dir = os.path.join(base_dir, output_dir)
 
+        # Create per-playlist subfolder if track has a playlist name
+        if item.playlist:
+            sanitized = item.playlist.replace("/", "-").replace("\\", "-").strip()
+            if sanitized:
+                output_dir = os.path.join(output_dir, sanitized)
+
         # Ensure output directory exists
         os.makedirs(output_dir, exist_ok=True)
 
@@ -191,16 +197,19 @@ class DownloadWorker(QThread):
 
             track_data = {
                 "artist": item.artist,
-                "track": item.track
+                "track": item.track,
+                "album": item.album or "",
+                "album_art_url": item.album_art_url or "",
             }
-            template = self.config.get("metadata_template", "basic")
+            template = self.config.get("metadata_template", "comprehensive")
             enable_musicbrainz = self.config.get("enable_musicbrainz_lookup", True)
 
             embed_track_metadata(
                 file_path,
                 track_data,
                 template=template,
-                allow_musicbrainz=enable_musicbrainz
+                allow_musicbrainz=enable_musicbrainz,
+                config=self.config,
             )
         except ImportError:
             pass


### PR DESCRIPTION
## Summary

- **Album art embedding (fixes #28):** `QueueItem` now carries `album_art_url` and `album` through the full GUI download pipeline. Previously these fields were dropped when tracks were added to the queue, so the metadata embedder had no URL to download cover art from. Also defaults to `"comprehensive"` metadata template (which has `embed_cover_art: True`).

- **Per-playlist folder organization:** Downloads from CSV imports and Spotify now create subfolders per playlist (`music/PlaylistName/track.mp3`) instead of dumping everything into a flat `music/` directory. Uses the playlist name already parsed from Exportify CSVs or Spotify API.

## Changes

| File | What changed |
|------|-------------|
| `gui/workers/download_queue.py` | Added `album`, `album_art_url` fields to `QueueItem`; `add_track`/`add_item`/`add_tracks` now pass them through |
| `gui/workers/download_worker.py` | `_download_single` creates per-playlist subdirs; `_embed_metadata` passes full track data + uses `"comprehensive"` template |
| `gui/views/welcome_view.py` | `_add_tracks_to_queue` passes `album_art_url` to queue |
| `gui/views/spotify_view.py` | `_add_single_to_queue` passes `album`, `album_art_url` to queue |

## Test plan

- [ ] Import a multi-playlist Exportify CSV — verify each playlist gets its own subfolder
- [ ] Import tracks via Spotify API — verify album art is embedded in downloaded MP3s
- [ ] Import from YouTube tab — verify downloads still work (no playlist folder created)
- [ ] Check ID3 tags of downloaded files for APIC (album art) frame