### PR TITLE
feat: concurrent multi-threaded downloads

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     "average_download_time": 20,
     "retry_attempts": 3,
     "retry_delay": 5,
+    "max_concurrent_downloads": 3,
     "auto_cleanup": False,
     "auto_backup": True,
     "max_backups": 10,
@@ -68,6 +69,7 @@ CONFIG_PROFILES = {
     "light": {
         "retry_attempts": 1,
         "retry_delay": 3,
+        "max_concurrent_downloads": 2,
         "auto_cleanup": False,
         "auto_backup": True,
         "max_backups": 5,
@@ -84,6 +86,7 @@ CONFIG_PROFILES = {
     "advanced": {
         "retry_attempts": 5,
         "retry_delay": 10,
+        "max_concurrent_downloads": 4,
         "auto_cleanup": False,
         "auto_backup": True,
         "max_backups": 20,
@@ -100,6 +103,7 @@ CONFIG_PROFILES = {
     "minimal": {
         "retry_attempts": 0,
         "retry_delay": 0,
+        "max_concurrent_downloads": 1,
         "auto_cleanup": False,
         "auto_backup": False,
         "max_backups": 0,
@@ -130,6 +134,7 @@ CONFIG_SCHEMA = {
     "average_download_time": {"type": (int, float), "required": False, "min": 1, "max": 300},
     "retry_attempts": {"type": int, "required": False, "min": 0, "max": 10},
     "retry_delay": {"type": (int, float), "required": False, "min": 0, "max": 60},
+    "max_concurrent_downloads": {"type": int, "required": False, "min": 1, "max": 8},
     "auto_cleanup": {"type": bool, "required": False},
     "auto_backup": {"type": bool, "required": False},
     "max_backups": {"type": int, "required": False, "min": 0, "max": 100},

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QPushButton, QLineEdit, QComboBox, QCheckBox,
     QGroupBox, QFormLayout, QFileDialog, QMessageBox,
     QSpacerItem, QSizePolicy, QScrollArea, QFrame,
-    QProgressBar
+    QProgressBar, QSpinBox
 )
 from PySide6.QtCore import Signal
 
@@ -244,6 +244,16 @@ class SettingsView(QWidget):
         self.retry_input.setMaximumWidth(200)
         download_layout.addWidget(self.retry_input)
 
+        concurrent_label = QLabel("Max concurrent downloads")
+        concurrent_label.setObjectName("muted")
+        download_layout.addWidget(concurrent_label)
+        self.concurrent_spinbox = QSpinBox()
+        self.concurrent_spinbox.setMinimum(1)
+        self.concurrent_spinbox.setMaximum(8)
+        self.concurrent_spinbox.setValue(3)
+        self.concurrent_spinbox.setMaximumWidth(200)
+        download_layout.addWidget(self.concurrent_spinbox)
+
         layout.addWidget(download_group)
 
         # Metadata Settings Group
@@ -313,6 +323,7 @@ class SettingsView(QWidget):
         self.redirect_uri_input.setText(self.config.get("spotify_redirect_uri", "http://127.0.0.1:8888/callback"))
         self.sleep_input.setText(str(self.config.get("sleep_between", 5)))
         self.retry_input.setText(str(self.config.get("retry_attempts", 3)))
+        self.concurrent_spinbox.setValue(self.config.get("max_concurrent_downloads", 3))
         self.metadata_check.setChecked(self.config.get("enable_metadata_embedding", True))
         self.template_combo.setCurrentText(self.config.get("metadata_template", "basic"))
         self.musicbrainz_check.setChecked(self.config.get("enable_musicbrainz_lookup", True))
@@ -586,6 +597,7 @@ class SettingsView(QWidget):
             self.config["spotify_client_id"] = self.client_id_input.text().strip()
             self.config["sleep_between"] = self._safe_int(self.sleep_input.text(), 5)
             self.config["retry_attempts"] = self._safe_int(self.retry_input.text(), 3)
+            self.config["max_concurrent_downloads"] = self.concurrent_spinbox.value()
             self.config["enable_metadata_embedding"] = self.metadata_check.isChecked()
             self.config["metadata_template"] = self.template_combo.currentText()
             self.config["enable_musicbrainz_lookup"] = self.musicbrainz_check.isChecked()

--- a/gui/workers/download_worker.py
+++ b/gui/workers/download_worker.py
@@ -1,7 +1,9 @@
-"""Download worker thread for GUI."""
+"""Download worker thread for GUI with concurrent thread pool."""
 
 import os
 import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
 from PySide6.QtCore import QThread, Signal
@@ -11,7 +13,10 @@ from gui.workers.download_queue import DownloadQueue, DownloadStatus, QueueItem
 
 class DownloadWorker(QThread):
     """
-    Worker thread that processes downloads from the queue.
+    Worker thread that processes downloads from the queue using a thread pool.
+
+    Downloads run concurrently up to max_concurrent_downloads threads.
+    The main QThread loop submits tasks to the pool and collects results.
 
     Signals:
         track_started: Emitted when a track download begins (artist, track)
@@ -33,9 +38,15 @@ class DownloadWorker(QThread):
         self.config = config
         self._cancelled = False
         self._paused = False
+        self._lock = threading.Lock()
+
+    @property
+    def max_workers(self) -> int:
+        """Get the max concurrent downloads from config."""
+        return max(1, min(8, self.config.get("max_concurrent_downloads", 3)))
 
     def run(self):
-        """Process all pending downloads in the queue."""
+        """Process all pending downloads in the queue using a thread pool."""
         from utils.ffmpeg import configure_ffmpeg_path
 
         # Configure FFmpeg path
@@ -57,60 +68,120 @@ class DownloadWorker(QThread):
 
         self.queue.set_running(True)
 
-        while not self._cancelled:
-            # Check for pause
-            if self._paused:
-                self.msleep(100)
-                continue
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures = {}
 
-            # Get next pending item
-            item = self.queue.get_next_pending()
-            if not item:
-                break
+            while not self._cancelled:
+                # Check for pause
+                if self._paused:
+                    self.msleep(100)
+                    continue
 
-            # Mark as downloading
-            self.queue.update_item_status(item.id, DownloadStatus.DOWNLOADING, progress=0)
-            self.track_started.emit(item.artist, item.track)
+                # Collect completed futures
+                done_ids = []
+                for future_id, future in futures.items():
+                    if future.done():
+                        done_ids.append(future_id)
 
-            # Download the track
-            success, file_path, error = self._download_single(item)
+                for future_id in done_ids:
+                    future = futures.pop(future_id)
+                    try:
+                        item, success, file_path, error = future.result()
+                    except Exception as e:
+                        # Unexpected exception from the pool thread
+                        item = self._get_item_by_future_id(future_id)
+                        if item:
+                            self.queue.update_item_status(
+                                item.id,
+                                DownloadStatus.FAILED,
+                                error_message=str(e)
+                            )
+                            self.track_failed.emit(item.id, str(e))
+                        fail_count += 1
+                        continue
 
+                    if self._cancelled:
+                        self.queue.update_item_status(
+                            item.id,
+                            DownloadStatus.CANCELLED,
+                            error_message="Cancelled by user"
+                        )
+                        continue
+
+                    if success:
+                        self.queue.update_item_status(
+                            item.id,
+                            DownloadStatus.COMPLETED,
+                            progress=100,
+                            file_path=file_path
+                        )
+                        self.track_completed.emit(item.id, True, file_path or "")
+                        success_count += 1
+                    else:
+                        self.queue.update_item_status(
+                            item.id,
+                            DownloadStatus.FAILED,
+                            error_message=error
+                        )
+                        self.track_failed.emit(item.id, error or "Unknown error")
+                        fail_count += 1
+
+                # Submit new tasks if pool has capacity
+                active_count = len(futures)
+                slots_available = self.max_workers - active_count
+
+                if slots_available > 0:
+                    for _ in range(slots_available):
+                        if self._cancelled or self._paused:
+                            break
+
+                        item = self.queue.get_next_pending()
+                        if not item:
+                            break
+
+                        # Mark as downloading and emit signal
+                        self.queue.update_item_status(
+                            item.id, DownloadStatus.DOWNLOADING, progress=0
+                        )
+                        self.track_started.emit(item.artist, item.track)
+
+                        # Submit to pool
+                        future = executor.submit(self._download_single, item)
+                        futures[item.id] = future
+
+                # If no active futures and no pending items, we're done
+                if not futures and not self.queue.has_pending():
+                    break
+
+                # Brief sleep to avoid busy-waiting
+                self.msleep(50)
+
+            # Handle cancellation: cancel remaining futures
             if self._cancelled:
-                self.queue.update_item_status(
-                    item.id,
-                    DownloadStatus.CANCELLED,
-                    error_message="Cancelled by user"
-                )
-                break
-
-            if success:
-                self.queue.update_item_status(
-                    item.id,
-                    DownloadStatus.COMPLETED,
-                    progress=100,
-                    file_path=file_path
-                )
-                self.track_completed.emit(item.id, True, file_path or "")
-                success_count += 1
-            else:
-                self.queue.update_item_status(
-                    item.id,
-                    DownloadStatus.FAILED,
-                    error_message=error
-                )
-                self.track_failed.emit(item.id, error or "Unknown error")
-                fail_count += 1
+                for future_id, future in futures.items():
+                    future.cancel()
+                # Wait for running futures to finish
+                for future_id, future in futures.items():
+                    if not future.cancelled():
+                        try:
+                            future.result(timeout=5)
+                        except Exception:
+                            pass
 
         self.queue.set_running(False)
         self.queue.mark_queue_completed()
         self.all_completed.emit(success_count, fail_count)
 
-    def _download_single(self, item: QueueItem) -> tuple[bool, Optional[str], Optional[str]]:
+    def _get_item_by_future_id(self, item_id: str) -> Optional[QueueItem]:
+        """Look up a queue item by its ID."""
+        return self.queue.get_item(item_id)
+
+    def _download_single(self, item: QueueItem) -> tuple:
         """
-        Download a single track.
+        Download a single track. Runs in a pool thread.
 
         Returns:
-            Tuple of (success, file_path, error_message)
+            Tuple of (item, success, file_path, error_message)
         """
         output_dir = self.config.get("output_dir", "music")
         audio_format = self.config.get("audio_format", "mp3")
@@ -127,7 +198,7 @@ class DownloadWorker(QThread):
                 base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
             output_dir = os.path.join(base_dir, output_dir)
 
-        # Ensure output directory exists
+        # Ensure output directory exists (thread-safe with exist_ok)
         os.makedirs(output_dir, exist_ok=True)
 
         query = f"{item.artist} - {item.track}"
@@ -162,24 +233,24 @@ class DownloadWorker(QThread):
                 if os.path.exists(expected_path):
                     # Embed metadata if enabled
                     self._embed_metadata(expected_path, item)
-                    return True, expected_path, None
+                    return item, True, expected_path, None
 
                 # Try to find with any extension
                 for ext in [audio_format, "mp3", "m4a", "opus", "webm"]:
                     check_path = os.path.join(output_dir, f"{filename}.{ext}")
                     if os.path.exists(check_path):
                         self._embed_metadata(check_path, item)
-                        return True, check_path, None
+                        return item, True, check_path, None
 
-                return True, None, None
+                return item, True, None, None
             else:
                 error_msg = stderr.strip() if stderr else "Download failed"
-                return False, None, error_msg
+                return item, False, None, error_msg
 
         except FileNotFoundError:
-            return False, None, "yt-dlp not found. Please install yt-dlp."
+            return item, False, None, "yt-dlp not found. Please install yt-dlp."
         except Exception as e:
-            return False, None, str(e)
+            return item, False, None, str(e)
 
     def _embed_metadata(self, file_path: str, item: QueueItem):
         """Embed metadata into the downloaded file."""


### PR DESCRIPTION
## Summary

- Downloads now process multiple tracks simultaneously using `ThreadPoolExecutor`
- Configurable via `max_concurrent_downloads` setting (default: 3, max: 8)
- Config profiles updated: light=2, advanced=4, minimal=1
- Added spinbox in Settings UI
- Existing signal API unchanged — no changes needed to downloads view

## Changes

| File | What changed |
|------|-------------|
| `config.py` | Added `max_concurrent_downloads` to defaults, schema, all profiles |
| `gui/workers/download_worker.py` | Rewrote `run()` to use `ThreadPoolExecutor`, futures-based result collection |
| `gui/views/settings_view.py` | Added concurrent downloads spinbox (1-8) |

## Test plan

- [ ] Download 5+ tracks — verify multiple download simultaneously
- [ ] Change concurrent count in settings, restart download — verify new count applies
- [ ] Pause/cancel with active concurrent downloads — verify clean stop
- [ ] Single download still works normally