### PR TITLE
fix(build): don't strip the bundled yt-dlp binary (breaks every download on macOS/Linux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,9 @@ jobs:
 
       - name: Build with PyInstaller (macOS)
         run: |
+          # Do not add --strip here: bin/yt-dlp is itself a PyInstaller onefile binary
+          # whose Python archive is appended to the executable, and strip discards that
+          # archive, leaving a bootloader stub that exits 255 on every run.
           pyinstaller \
             --name "Harmoni" \
             --windowed \
@@ -141,7 +144,6 @@ jobs:
             --add-binary "bin/yt-dlp:bin" \
             --add-data "config.json.example:." \
             --add-data "data:data" \
-            --strip \
             gui_main.py
 
       - name: Detect architecture
@@ -209,6 +211,9 @@ jobs:
 
       - name: Build with PyInstaller (Linux)
         run: |
+          # Do not add --strip here: bin/yt-dlp is itself a PyInstaller onefile binary
+          # whose Python archive is appended to the executable, and strip discards that
+          # archive, leaving a bootloader stub that exits 255 on every run.
           pyinstaller \
             --name "Harmoni" \
             --windowed \
@@ -219,7 +224,6 @@ jobs:
             --add-binary "bin/yt-dlp:bin" \
             --add-data "config.json.example:." \
             --add-data "data:data" \
-            --strip \
             gui_main.py
 
       - name: Package as tar.gz (Linux)

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -61,6 +61,9 @@ sips -z 1024 1024 gui/resources/icons/app/app_icon.png --out icon.iconset/icon_5
 iconutil -c icns icon.iconset -o HARMONI.icns
 
 # Build with PyInstaller
+# Do not add --strip here: bin/yt-dlp is itself a PyInstaller onefile binary whose
+# Python archive is appended to the executable, and strip discards that archive,
+# leaving a bootloader stub that exits 255 on every run.
 echo "=== Building with PyInstaller ==="
 pyinstaller \
     --name "HARMONI" \
@@ -73,7 +76,6 @@ pyinstaller \
     --add-binary "bin/yt-dlp:bin" \
     --add-data "config.json.example:." \
     --add-data "data:data" \
-    --strip \
     gui_main.py
 
 # Create DMG


### PR DESCRIPTION
## Summary

The macOS and Linux release artifacts ship a **non-functional `yt-dlp`**, so **every download fails**. The cause is `--strip` in the PyInstaller invocation.

`yt-dlp_macos` / `yt-dlp_linux` are themselves PyInstaller **onefile** binaries — their Python archive is *appended* to the executable. `strip` rewrites the binary and discards that appended archive, leaving only the ~100KB bootloader stub.

## Reproduction

Stripping a freshly downloaded release asset reproduces it exactly:

```console
$ curl -fL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos -o yt-dlp
$ chmod +x yt-dlp && ./yt-dlp --version
2026.07.04                 # 38,256,544 bytes — works

$ strip yt-dlp && ./yt-dlp --version
[PYI-50027:ERROR] Could not load PyInstaller's embedded PKG archive from the executable (yt-dlp)
                           # 171,424 bytes — broken
```

And the shipped macOS build matches:

```console
$ stat -f%z /Applications/Harmoni.app/Contents/Frameworks/bin/yt-dlp
106800
$ /Applications/Harmoni.app/Contents/Frameworks/bin/yt-dlp --version
[PYI-47209:ERROR] Could not load PyInstaller's embedded PKG archive from the executable (...)
$ echo $?
255
```

## Why it fails every track, with no fallback

`gui_main.py::configure_bundled_binaries()` and `utils/ffmpeg.py::configure_ffmpeg_path()` both prepend the bundle's `bin/` to `PATH`. `gui/workers/download_worker.py` then invokes bare `yt-dlp`, which resolves to the stub — so the broken binary **shadows any working yt-dlp the user already has installed**, rather than falling back to it. Every track fails with exit 255 and an empty output directory.

## Fix

Drop `--strip` from the macOS and Linux PyInstaller invocations in `.github/workflows/build.yml` and `build-macos.sh`, plus a comment at each site so it isn't reintroduced.

- **Windows is unaffected** — that job never passed `--strip`, which is exactly why only the macOS/Linux artifacts are broken.
- **`HARMONI.spec` already sets `strip=False`.** This makes the CLI builds consistent with the spec.
- `--strip` also strips the bundled Qt/PySide6 libraries, and PyInstaller's docs advise against it generally.

## Verification

I replaced the stub with an unstripped `yt-dlp` inside an installed bundle and re-ran the exact command `download_worker.py` builds, under the same environment a Finder-launched app gets:

```console
$ yt-dlp "ytsearch1:<artist> - <track>" -x --audio-format mp3 -o "..." --no-playlist --quiet --progress
$ echo $?
0
```

Bundled yt-dlp extracts, bundled ffmpeg transcodes, a valid mp3 lands on disk. Downloads that previously failed 100% of the time now succeed.

## Possibly related — not addressed in this PR

While debugging I also hit a reproducible **`SIGSEGV` at startup** (`EXC_BAD_ACCESS`, `KERN_INVALID_ADDRESS at 0x10`) that makes the app unlaunchable. It triggers whenever `check_ytdlp_updates()` reports an update is available — e.g. when `ytdlp_path` points at an older yt-dlp, or once the bundled yt-dlp falls behind PyPI — and the `QMessageBox.information(...)` at `gui_main.py:212` is reached:

```
Sbk_QMessageBoxFunc_information
QMessageBox::QMessageBox → QDialog::QDialog → QWidget::QWidget → QWidgetPrivate::init
QMetaObject::cast → PySide::SignalManager::retrieveMetaObject → metaBuilderFromDict
<crash>
```

Note the `except Exception: pass` around that block can't catch it — a segfault takes the process down. Since the backtrace bottoms out in PySide6 metaobject code, I suspect the same `--strip` flag (which also strips the bundled Qt/PySide6 dylibs) is the cause, and that this PR may fix it as a side effect — but I have not confirmed that, so I've left it out of scope. Worth a look either way: as written, the app hard-crashes on startup whenever a yt-dlp update exists, which will recur on every yt-dlp release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
