### PR TITLE
feat(gui): add download controls, parallelism, and richer progress

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,9 @@ DEFAULT_CONFIG = {
 
     "output_dir": "music",
     "audio_format": "mp3",
+    "download_speed_limit_mbps": 0,  # 0 = unlimited (Mbps, megabits/sec)
+    "concurrent_downloads": 3,  # how many downloads run in parallel (1-8)
+    "skip_existing_files": True,  # skip tracks already present in output_dir
     "sleep_between": 5,
     "average_download_time": 20,
     "retry_attempts": 3,
@@ -128,6 +131,9 @@ CONFIG_SCHEMA = {
         "required": True,
         "choices": ["mp3", "wav", "flac", "aac", "ogg", "m4a"],
     },
+    "download_speed_limit_mbps": {"type": (int, float), "required": False, "min": 0, "max": 1000},
+    "concurrent_downloads": {"type": int, "required": False, "min": 1, "max": 8},
+    "skip_existing_files": {"type": bool, "required": False},
     "sleep_between": {"type": (int, float), "required": True, "min": 0, "max": 60},
     "average_download_time": {"type": (int, float), "required": False, "min": 1, "max": 300},
     "retry_attempts": {"type": int, "required": False, "min": 0, "max": 10},

--- a/gui/views/downloads_view.py
+++ b/gui/views/downloads_view.py
@@ -1,16 +1,27 @@
 """Downloads view showing the download queue and progress."""
 
+import time
+
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QTableWidget, QTableWidgetItem,
     QHeaderView, QProgressBar, QMessageBox,
-    QAbstractItemView, QFrame, QSpacerItem, QSizePolicy
+    QAbstractItemView, QFrame, QSpacerItem, QSizePolicy,
+    QSlider
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
+from config import save_config
 from gui.workers.download_queue import DownloadQueue, DownloadStatus
 from gui.workers.download_worker import DownloadWorker
+
+# Downloads-view speed slider range (Mbps); 0 = unlimited.
+SPEED_LIMIT_MAX_MBPS = 100
+
+# Parallel-downloads slider range (must match the worker's 1-8 clamp).
+PARALLEL_MIN = 1
+PARALLEL_MAX = 8
 
 
 class StatCard(QFrame):
@@ -53,6 +64,7 @@ class DownloadsView(QWidget):
         self.config = config
         self.queue = queue
         self.worker = None
+        self._download_start_time = None  # monotonic time when a run began (for ETA)
         self._setup_ui()
         self._connect_signals()
 
@@ -133,12 +145,80 @@ class DownloadsView(QWidget):
         self.clear_done_btn.clicked.connect(self._clear_completed)
         controls_layout.addWidget(self.clear_done_btn)
 
+        self.open_folder_btn = QPushButton("Open Folder")
+        self.open_folder_btn.setObjectName("secondary")
+        self.open_folder_btn.clicked.connect(self._open_output_folder)
+        controls_layout.addWidget(self.open_folder_btn)
+
         self.clear_all_btn = QPushButton("Clear All")
         self.clear_all_btn.setObjectName("danger")
         self.clear_all_btn.clicked.connect(self._clear_all)
         controls_layout.addWidget(self.clear_all_btn)
 
         layout.addWidget(controls)
+
+        # Speed limit bar
+        speed_frame = QFrame()
+        speed_frame.setObjectName("card")
+        speed_layout = QHBoxLayout(speed_frame)
+        speed_layout.setContentsMargins(16, 12, 16, 12)
+        speed_layout.setSpacing(12)
+
+        speed_title = QLabel("Speed Limit")
+        speed_title.setStyleSheet("font-weight: 600; background: transparent;")
+        speed_layout.addWidget(speed_title)
+
+        self.speed_slider = QSlider(Qt.Horizontal)
+        self.speed_slider.setMinimum(0)
+        self.speed_slider.setMaximum(SPEED_LIMIT_MAX_MBPS)
+        self.speed_slider.setValue(self._current_speed_limit())
+        self.speed_slider.setTickPosition(QSlider.TicksBelow)
+        self.speed_slider.setTickInterval(10)
+        self.speed_slider.valueChanged.connect(self._on_speed_changed)
+        self.speed_slider.sliderReleased.connect(self._save_speed_limit)
+        speed_layout.addWidget(self.speed_slider, 1)
+
+        self.speed_value_label = QLabel()
+        self.speed_value_label.setMinimumWidth(90)
+        self.speed_value_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.speed_value_label.setStyleSheet("font-weight: 600; color: #3c92de; background: transparent;")
+        speed_layout.addWidget(self.speed_value_label)
+
+        self._update_speed_label(self.speed_slider.value())
+
+        layout.addWidget(speed_frame)
+
+        # Parallel downloads bar
+        parallel_frame = QFrame()
+        parallel_frame.setObjectName("card")
+        parallel_layout = QHBoxLayout(parallel_frame)
+        parallel_layout.setContentsMargins(16, 12, 16, 12)
+        parallel_layout.setSpacing(12)
+
+        parallel_title = QLabel("Parallel Downloads")
+        parallel_title.setStyleSheet("font-weight: 600; background: transparent;")
+        parallel_layout.addWidget(parallel_title)
+
+        self.parallel_slider = QSlider(Qt.Horizontal)
+        self.parallel_slider.setMinimum(PARALLEL_MIN)
+        self.parallel_slider.setMaximum(PARALLEL_MAX)
+        self.parallel_slider.setValue(self._current_parallel())
+        self.parallel_slider.setTickPosition(QSlider.TicksBelow)
+        self.parallel_slider.setTickInterval(1)
+        self.parallel_slider.setPageStep(1)
+        self.parallel_slider.valueChanged.connect(self._on_parallel_changed)
+        self.parallel_slider.sliderReleased.connect(self._save_parallel)
+        parallel_layout.addWidget(self.parallel_slider, 1)
+
+        self.parallel_value_label = QLabel()
+        self.parallel_value_label.setMinimumWidth(90)
+        self.parallel_value_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.parallel_value_label.setStyleSheet("font-weight: 600; color: #3c92de; background: transparent;")
+        parallel_layout.addWidget(self.parallel_value_label)
+
+        self._update_parallel_label(self.parallel_slider.value())
+
+        layout.addWidget(parallel_frame)
 
         # Queue table
         self.table = QTableWidget()
@@ -183,7 +263,69 @@ class DownloadsView(QWidget):
         self.progress_text.setStyleSheet("font-weight: 600; color: #3c92de; background: transparent;")
         progress_layout.addWidget(self.progress_text)
 
+        self.overall_eta_label = QLabel("")
+        self.overall_eta_label.setMinimumWidth(110)
+        self.overall_eta_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.overall_eta_label.setStyleSheet("color: #9a9ab0; background: transparent;")
+        progress_layout.addWidget(self.overall_eta_label)
+
         layout.addWidget(progress_frame)
+
+    def _current_speed_limit(self) -> int:
+        """Read the saved speed limit (Mbps) clamped to the slider range."""
+        try:
+            value = int(round(float(self.config.get("download_speed_limit_mbps", 0) or 0)))
+        except (TypeError, ValueError):
+            value = 0
+        return max(0, min(value, SPEED_LIMIT_MAX_MBPS))
+
+    def _update_speed_label(self, value: int):
+        """Update the text next to the speed slider."""
+        if value <= 0:
+            self.speed_value_label.setText("Unlimited")
+        else:
+            self.speed_value_label.setText(f"{value} Mbps")
+
+    def _on_speed_changed(self, value: int):
+        """Live-apply the slider value to the shared config (no disk write yet)."""
+        self._update_speed_label(value)
+        # Same dict the worker reads at download time, so it takes effect
+        # for downloads that start after this change.
+        self.config["download_speed_limit_mbps"] = value
+
+    def _save_speed_limit(self):
+        """Persist the speed limit to disk when the user releases the slider."""
+        self.config["download_speed_limit_mbps"] = self.speed_slider.value()
+        try:
+            save_config(self.config)
+        except Exception:
+            pass  # non-fatal; the in-memory value still applies this session
+
+    def _current_parallel(self) -> int:
+        """Read the saved parallel-download count clamped to the slider range."""
+        try:
+            value = int(self.config.get("concurrent_downloads", 3))
+        except (TypeError, ValueError):
+            value = 3
+        return max(PARALLEL_MIN, min(value, PARALLEL_MAX))
+
+    def _update_parallel_label(self, value: int):
+        """Update the text next to the parallel-downloads slider."""
+        suffix = "download" if value == 1 else "downloads"
+        self.parallel_value_label.setText(f"{value} {suffix}")
+
+    def _on_parallel_changed(self, value: int):
+        """Live-apply the parallel count to the shared config (no disk write yet)."""
+        self._update_parallel_label(value)
+        self.config["concurrent_downloads"] = value
+
+    def _save_parallel(self):
+        """Persist the parallel-download count when the user releases the slider."""
+        self.config["concurrent_downloads"] = self.parallel_slider.value()
+        try:
+            save_config(self.config)
+        except Exception:
+            pass  # non-fatal; the in-memory value still applies this session
 
     def _connect_signals(self):
         self.queue.item_added.connect(self._on_item_added)
@@ -210,8 +352,9 @@ class DownloadsView(QWidget):
         progress.setMinimum(0)
         progress.setMaximum(100)
         progress.setValue(item.progress)
-        progress.setTextVisible(False)
-        progress.setFixedHeight(6)
+        progress.setFormat("%p%")
+        progress.setTextVisible(True)
+        progress.setFixedHeight(16)
         self.table.setCellWidget(row, 4, progress)
 
         self._update_stats(self.queue.pending_count)
@@ -220,7 +363,15 @@ class DownloadsView(QWidget):
         for row in range(self.table.rowCount()):
             if self.table.item(row, 0).data(Qt.UserRole) == item.id:
                 status_item = self.table.item(row, 3)
-                status_item.setText(item.status.value.title())
+                if item.status == DownloadStatus.DOWNLOADING:
+                    parts = [f"Downloading {item.progress}%"]
+                    if getattr(item, "speed", ""):
+                        parts.append(item.speed)
+                    if getattr(item, "eta", ""):
+                        parts.append(f"ETA {item.eta}")
+                    status_item.setText("  •  ".join(parts))
+                else:
+                    status_item.setText(item.status.value.title())
 
                 if item.status == DownloadStatus.COMPLETED:
                     status_item.setForeground(QColor("#4caf50"))
@@ -260,12 +411,80 @@ class DownloadsView(QWidget):
         percent = int((completed / total) * 100)
         self.overall_progress.setValue(percent)
         self.progress_text.setText(f"{percent}%")
+        self._update_overall_eta(total, completed)
+
+    def _update_overall_eta(self, total: int, completed: int):
+        """Show a rough estimate of the time remaining for the whole queue."""
+        remaining = total - completed
+        # Only show an estimate while a run is actually in progress.
+        if remaining <= 0 or self._download_start_time is None or not self.queue.is_running:
+            self.overall_eta_label.setText("")
+            return
+
+        workers = max(1, self._current_parallel())
+        if completed > 0:
+            # Measured wall-clock average per finished item already reflects
+            # how many downloads run in parallel.
+            elapsed = time.monotonic() - self._download_start_time
+            avg = elapsed / completed
+        else:
+            # Nothing finished yet: fall back to the configured rough estimate.
+            try:
+                avg_download = float(self.config.get("average_download_time", 20) or 20)
+            except (TypeError, ValueError):
+                avg_download = 20.0
+            avg = avg_download / workers
+
+        eta_seconds = avg * remaining
+        self.overall_eta_label.setText(f"~ {self._format_duration(eta_seconds)} left")
+
+    @staticmethod
+    def _format_duration(seconds: float) -> str:
+        seconds = int(max(0, seconds))
+        if seconds >= 3600:
+            return f"{seconds // 3600}h {(seconds % 3600) // 60}m"
+        if seconds >= 60:
+            return f"{seconds // 60}m {seconds % 60:02d}s"
+        return f"{seconds}s"
+
+    def _resolve_output_dir(self) -> str:
+        """Resolve the configured output dir to an absolute path (project-root relative)."""
+        import os
+        import sys
+        output_dir = self.config.get("output_dir", "music")
+        if not os.path.isabs(output_dir):
+            if getattr(sys, "frozen", False):
+                base_dir = os.path.dirname(sys.executable)
+            else:
+                # …/gui/views/downloads_view.py -> project root
+                base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+            output_dir = os.path.join(base_dir, output_dir)
+        return output_dir
+
+    def _open_output_folder(self):
+        """Open the downloads folder in the OS file manager."""
+        import os
+        import sys
+        import subprocess
+
+        path = self._resolve_output_dir()
+        try:
+            os.makedirs(path, exist_ok=True)
+            if sys.platform == "win32":
+                os.startfile(path)  # type: ignore[attr-defined]
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", path])
+            else:
+                subprocess.Popen(["xdg-open", path])
+        except Exception as e:
+            QMessageBox.warning(self, "Open Folder", f"Could not open folder:\n{path}\n\n{e}")
 
     def _on_queue_completed(self, success: int, failed: int):
         self.start_btn.setEnabled(True)
         self.pause_btn.setEnabled(False)
         self.cancel_btn.setEnabled(False)
         self.pause_btn.setText("Pause")
+        self.overall_eta_label.setText("")
 
         if failed > 0:
             QMessageBox.information(
@@ -285,6 +504,7 @@ class DownloadsView(QWidget):
             QMessageBox.information(self, "No Downloads", "No tracks in queue to download.")
             return
 
+        self._download_start_time = time.monotonic()
         self.worker = DownloadWorker(self.queue, self.config)
         self.worker.all_completed.connect(self._on_queue_completed)
         self.worker.start()

--- a/gui/views/settings_view.py
+++ b/gui/views/settings_view.py
@@ -228,6 +228,12 @@ class SettingsView(QWidget):
         download_layout = QVBoxLayout(download_group)
         download_layout.setSpacing(10)
 
+        self.skip_existing_check = QCheckBox("Skip tracks already downloaded")
+        download_layout.addWidget(self.skip_existing_check)
+
+        self.cleanup_check = QCheckBox("Clean up temporary files after downloads")
+        download_layout.addWidget(self.cleanup_check)
+
         sleep_label = QLabel("Sleep between downloads (seconds)")
         sleep_label.setObjectName("muted")
         download_layout.addWidget(sleep_label)
@@ -325,6 +331,8 @@ class SettingsView(QWidget):
         self.format_combo.setCurrentText(self.config.get("audio_format", "mp3"))
         self.client_id_input.setText(self.config.get("spotify_client_id", ""))
         self.redirect_uri_input.setText(self.config.get("spotify_redirect_uri", "http://127.0.0.1:8888/callback"))
+        self.skip_existing_check.setChecked(self.config.get("skip_existing_files", True))
+        self.cleanup_check.setChecked(self.config.get("auto_cleanup", False))
         self.sleep_input.setText(str(self.config.get("sleep_between", 5)))
         self.retry_input.setText(str(self.config.get("retry_attempts", 3)))
         self.ytdlp_args_input.setText(self.config.get("ytdlp_extra_args", ""))
@@ -600,6 +608,8 @@ class SettingsView(QWidget):
             self.config["output_dir"] = output_dir
             self.config["audio_format"] = self.format_combo.currentText()
             self.config["spotify_client_id"] = self.client_id_input.text().strip()
+            self.config["skip_existing_files"] = self.skip_existing_check.isChecked()
+            self.config["auto_cleanup"] = self.cleanup_check.isChecked()
             self.config["sleep_between"] = self._safe_int(self.sleep_input.text(), 5)
             self.config["retry_attempts"] = self._safe_int(self.retry_input.text(), 3)
             self.config["ytdlp_extra_args"] = self.ytdlp_args_input.text().strip()

--- a/gui/workers/download_queue.py
+++ b/gui/workers/download_queue.py
@@ -28,6 +28,8 @@ class QueueItem:
     progress: int = 0  # 0-100
     error_message: Optional[str] = None
     file_path: Optional[str] = None
+    speed: str = ""  # live download speed text, e.g. "512KiB/s"
+    eta: str = ""  # live estimated time remaining, e.g. "00:07"
 
 
 class DownloadQueue(QObject):

--- a/gui/workers/download_worker.py
+++ b/gui/workers/download_worker.py
@@ -1,6 +1,7 @@
 """Download worker thread for GUI."""
 
 import os
+import re
 import subprocess
 from typing import Optional
 
@@ -36,14 +37,16 @@ class DownloadWorker(QThread):
         self._paused = False
 
     def run(self):
-        """Process all pending downloads in the queue."""
+        """Process all pending downloads in the queue (parallel)."""
+        import threading
+        from concurrent.futures import ThreadPoolExecutor, FIRST_COMPLETED, wait
+
         from utils.ffmpeg import configure_ffmpeg_path
 
         # Configure FFmpeg path
         try:
             configure_ffmpeg_path()
         except FileNotFoundError as e:
-            # FFmpeg not found - fail all downloads
             for item in self.queue.get_pending_items():
                 self.queue.update_item_status(
                     item.id,
@@ -53,28 +56,58 @@ class DownloadWorker(QThread):
                 self.track_failed.emit(item.id, str(e))
             return
 
+        max_workers = int(self.config.get("concurrent_downloads", 3))
+        max_workers = max(1, min(max_workers, 8))
+        # Used so the per-process --limit-rate is split across concurrent
+        # downloads and the combined speed respects the configured limit.
+        self._max_workers = max_workers
+
         success_count = 0
         fail_count = 0
+        count_lock = threading.Lock()
 
         self.queue.set_running(True)
 
-        while not self._cancelled:
-            # Check for pause
-            if self._paused:
-                self.msleep(100)
-                continue
+        # Retry config (previously saved but never applied in the GUI).
+        try:
+            max_attempts = max(1, int(self.config.get("retry_attempts", 3)) + 1)
+        except (TypeError, ValueError):
+            max_attempts = 1
+        try:
+            retry_delay = max(0.0, float(self.config.get("retry_delay", 5)))
+        except (TypeError, ValueError):
+            retry_delay = 5.0
 
-            # Get next pending item
-            item = self.queue.get_next_pending()
-            if not item:
-                break
-
-            # Mark as downloading
+        def process_item(item):
+            nonlocal success_count, fail_count
             self.queue.update_item_status(item.id, DownloadStatus.DOWNLOADING, progress=0)
             self.track_started.emit(item.artist, item.track)
 
-            # Download the track
-            success, file_path, error = self._download_single(item)
+            def on_progress(pct, speed="", eta=""):
+                it = self.queue.get_item(item.id)
+                if it is not None:
+                    it.speed = speed
+                    it.eta = eta
+                self.queue.update_item_status(
+                    item.id, DownloadStatus.DOWNLOADING, progress=pct
+                )
+                self.track_progress.emit(item.id, pct)
+
+            # Try the download, retrying on failure per retry_attempts.
+            success, file_path, error = False, None, None
+            for attempt in range(1, max_attempts + 1):
+                if self._cancelled:
+                    break
+                success, file_path, error = self._download_single(item, on_progress)
+                if success or self._cancelled:
+                    break
+                if attempt < max_attempts:
+                    # Exponential backoff, but stop early if cancelled.
+                    delay = retry_delay * (2 ** (attempt - 1))
+                    waited = 0.0
+                    while waited < delay and not self._cancelled:
+                        self.msleep(100)
+                        waited += 0.1
 
             if self._cancelled:
                 self.queue.update_item_status(
@@ -82,7 +115,7 @@ class DownloadWorker(QThread):
                     DownloadStatus.CANCELLED,
                     error_message="Cancelled by user"
                 )
-                break
+                return
 
             if success:
                 self.queue.update_item_status(
@@ -92,7 +125,8 @@ class DownloadWorker(QThread):
                     file_path=file_path
                 )
                 self.track_completed.emit(item.id, True, file_path or "")
-                success_count += 1
+                with count_lock:
+                    success_count += 1
             else:
                 self.queue.update_item_status(
                     item.id,
@@ -100,39 +134,135 @@ class DownloadWorker(QThread):
                     error_message=error
                 )
                 self.track_failed.emit(item.id, error or "Unknown error")
-                fail_count += 1
+                with count_lock:
+                    fail_count += 1
+
+        futures = set()
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            while not self._cancelled:
+                # Pause: don't submit new items, let running ones finish
+                if self._paused:
+                    self.msleep(100)
+                    continue
+
+                # Fill available slots
+                while len(futures) < max_workers:
+                    item = self.queue.get_next_pending()
+                    if not item:
+                        break
+                    # Reserve the item so it isn't picked twice
+                    item.status = DownloadStatus.DOWNLOADING
+                    futures.add(executor.submit(process_item, item))
+
+                if not futures:
+                    break  # nothing running, nothing pending
+
+                done, futures = wait(futures, timeout=0.2, return_when=FIRST_COMPLETED)
+
+            # Wait for any still-running downloads to finish
+            if futures:
+                wait(futures)
 
         self.queue.set_running(False)
+        self._write_failed_report()
+        self._post_download_maintenance()
         self.queue.mark_queue_completed()
         self.all_completed.emit(success_count, fail_count)
 
-    def _download_single(self, item: QueueItem) -> tuple[bool, Optional[str], Optional[str]]:
-        """
-        Download a single track.
+    def _post_download_maintenance(self):
+        """Run the existing cleanup/backup managers after a download run."""
+        # Clean up temp/partial files left in the output folder.
+        if self.config.get("auto_cleanup", False):
+            try:
+                from managers.cleanup_manager import cleanup_after_download
+                # Point the cleaner at the resolved (absolute) output folder.
+                cleanup_after_download({**self.config, "output_dir": self._resolve_output_dir()})
+            except Exception:
+                pass  # maintenance must never break the run
 
-        Returns:
-            Tuple of (success, file_path, error_message)
-        """
+        # Back up the data files (tracks.json / playlists.json).
+        if self.config.get("auto_backup", True):
+            try:
+                from managers.backup_manager import backup_all
+                backup_all(self.config)
+            except Exception:
+                pass
+
+    def _write_failed_report(self):
+        """Write a txt list of tracks that failed to download into the output folder."""
+        failed = [i for i in self.queue.items if i.status == DownloadStatus.FAILED]
+        report_path = os.path.join(self._resolve_output_dir(), "inmeyen_sarkilar.txt")
+
+        try:
+            if not failed:
+                # Nothing failed this run — remove any stale report.
+                if os.path.exists(report_path):
+                    os.remove(report_path)
+                return
+
+            from datetime import datetime
+
+            lines = [
+                f"# Inmeyen sarkilar - {datetime.now():%Y-%m-%d %H:%M}",
+                f"# Toplam: {len(failed)}",
+                "",
+            ]
+            for i in failed:
+                reason = (i.error_message or "Bilinmeyen hata").strip().replace("\n", " ")
+                lines.append(f"{i.artist} - {i.track}\t| {reason}")
+
+            with open(report_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+        except Exception:
+            pass  # reporting must never break the download run
+
+    def _resolve_output_dir(self) -> str:
+        """Resolve the output directory to an absolute path (project-root relative)."""
         output_dir = self.config.get("output_dir", "music")
-        audio_format = self.config.get("audio_format", "mp3")
-
-        # Handle relative paths - make absolute from project root
         if not os.path.isabs(output_dir):
-            # Get the project root (where gui_main.py is)
             import sys
             if getattr(sys, 'frozen', False):
                 # Running as compiled executable
                 base_dir = os.path.dirname(sys.executable)
             else:
-                # Running as script
+                # Running as script (…/gui/workers/download_worker.py -> project root)
                 base_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
             output_dir = os.path.join(base_dir, output_dir)
+        return output_dir
+
+    def _download_single(self, item: QueueItem, progress_cb=None) -> tuple[bool, Optional[str], Optional[str]]:
+        """
+        Download a single track.
+
+        progress_cb: optional callable(percent: int) invoked as the download
+        advances so the GUI can show per-track progress.
+
+        Returns:
+            Tuple of (success, file_path, error_message)
+        """
+        output_dir = self._resolve_output_dir()
+        audio_format = self.config.get("audio_format", "mp3")
 
         # Ensure output directory exists
         os.makedirs(output_dir, exist_ok=True)
 
         query = f"{item.artist} - {item.track}"
         filename = query.replace("/", "-").replace("\\", "-")
+
+        # Skip if this track was already downloaded to the output folder.
+        if self.config.get("skip_existing_files", True):
+            expected = os.path.join(output_dir, f"{filename}.{audio_format}")
+            if os.path.exists(expected):
+                return True, expected, None
+            # Fall back to a normalized match: handles case/punctuation and any
+            # audio extension, using the shared track checker.
+            try:
+                from utils.track_checker import track_key, existing_track_keys_in_dir
+                key = track_key({"artist": item.artist, "track": item.track})
+                if key in existing_track_keys_in_dir(output_dir):
+                    return True, None, None
+            except Exception:
+                pass  # matching is best-effort; fall through to downloading
 
         cmd = [
             "yt-dlp",
@@ -142,21 +272,57 @@ class DownloadWorker(QThread):
             "-o", os.path.join(output_dir, f"{filename}.%(ext)s"),
             "--no-playlist",
             "--quiet",
-            "--progress"
+            "--progress",
+            "--newline"  # emit each progress update on its own line so we can parse it
         ]
-        cmd.extend(build_extra_ytdlp_args(self.config))
+        cmd.extend(build_extra_ytdlp_args(
+            self.config,
+            speed_limit_divisor=getattr(self, "_max_workers", 1),
+        ))
+
+        # Gentle pacing: sleep before each download to avoid rate-limiting.
+        try:
+            sleep_between = float(self.config.get("sleep_between", 0) or 0)
+        except (TypeError, ValueError):
+            sleep_between = 0.0
+        if sleep_between > 0:
+            cmd.extend(["--sleep-interval", f"{sleep_between:g}"])
 
         try:
             process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.STDOUT,  # merge so progress/errors come on one stream
                 text=True,
                 creationflags=subprocess.CREATE_NO_WINDOW if os.name == 'nt' else 0
             )
 
-            # Wait for completion
-            stdout, stderr = process.communicate()
+            # Read line by line, parsing yt-dlp's "[download]  45.2% of ..." lines.
+            output_lines = []
+            percent_re = re.compile(r"(\d{1,3}(?:\.\d+)?)%")
+            speed_re = re.compile(r"at\s+([\d.]+\s*[KMGT]?i?B/s)")
+            eta_re = re.compile(r"ETA\s+([\d:]+)")
+            last_pct = -1
+            for line in process.stdout:
+                output_lines.append(line)
+                if self._cancelled:
+                    break
+                match = percent_re.search(line)
+                if match and progress_cb:
+                    try:
+                        pct = int(float(match.group(1)))
+                    except ValueError:
+                        continue
+                    pct = max(0, min(pct, 100))
+                    # Only report on whole-percent changes to limit signal spam.
+                    if pct != last_pct:
+                        last_pct = pct
+                        sp = speed_re.search(line)
+                        et = eta_re.search(line)
+                        speed = sp.group(1).replace(" ", "") if sp else ""
+                        eta = et.group(1) if et else ""
+                        progress_cb(pct, speed, eta)
+            process.wait()
 
             if process.returncode == 0:
                 # Try to find the downloaded file
@@ -175,7 +341,13 @@ class DownloadWorker(QThread):
 
                 return True, None, None
             else:
-                error_msg = stderr.strip() if stderr else "Download failed"
+                # Prefer explicit ERROR lines; fall back to the last output line.
+                error_lines = [ln.strip() for ln in output_lines if "ERROR" in ln]
+                if error_lines:
+                    error_msg = error_lines[-1]
+                else:
+                    non_empty = [ln.strip() for ln in output_lines if ln.strip()]
+                    error_msg = non_empty[-1] if non_empty else "Download failed"
                 return False, None, error_msg
 
         except FileNotFoundError:

--- a/utils/ytdlp_args.py
+++ b/utils/ytdlp_args.py
@@ -3,17 +3,39 @@
 import shlex
 
 
-def build_extra_ytdlp_args(config: dict) -> list[str]:
+def build_extra_ytdlp_args(config: dict, speed_limit_divisor: int = 1) -> list[str]:
     """
     Build the list of extra CLI arguments to append to a yt-dlp command,
     based on user-supplied config. Lets users pass arbitrary yt-dlp flags
     (e.g. --cookies cookies.txt, --limit-rate 1M) and ffmpeg flags
     (forwarded via yt-dlp's --postprocessor-args) without code changes.
+
+    speed_limit_divisor: yt-dlp's --limit-rate applies per process. When
+    several downloads run in parallel, pass the number of concurrent
+    downloads here so the configured limit is split across them and the
+    *combined* throughput stays under the user's target.
     """
     if not config:
         return []
 
     args: list[str] = []
+
+    # Speed limit (Mbps set from the Downloads view slider). Converted to
+    # bytes/sec for yt-dlp's --limit-rate. 0 (or invalid) means unlimited.
+    try:
+        speed_limit_mbps = float(config.get("download_speed_limit_mbps", 0) or 0)
+    except (TypeError, ValueError):
+        speed_limit_mbps = 0.0
+    try:
+        divisor = max(1, int(speed_limit_divisor))
+    except (TypeError, ValueError):
+        divisor = 1
+    if speed_limit_mbps > 0:
+        # Mbps (megabits/sec) -> bytes/sec: * 1_000_000 / 8, then split
+        # across the concurrent downloads so the total respects the limit.
+        bytes_per_sec = int(speed_limit_mbps * 1_000_000 / 8 / divisor)
+        if bytes_per_sec > 0:
+            args.extend(["--limit-rate", str(bytes_per_sec)])
 
     ytdlp_extra = (config.get("ytdlp_extra_args") or "").strip()
     if ytdlp_extra:


### PR DESCRIPTION
Introduce a set of download-experience improvements to the desktop GUI.

Concurrency and throughput:
- Parallel downloads with a configurable concurrency control (1-8) surfaced in the Downloads view.
- Aggregate speed limit (Mbps) divided across active downloads so the combined throughput stays within the configured target.
- Map sleep_between to yt-dlp's --sleep-interval for gentler request pacing.

Reliability:
- Duplicate-aware queue that skips tracks already present in the output directory using normalized filename matching.
- Automatic retry with exponential backoff, honoring the existing retry_attempts and retry_delay configuration.
- Post-run report of failed downloads written to the output directory.
- Integrate the existing cleanup and backup managers into the GUI worker.

Progress and UX:
- Real-time per-track progress parsed from yt-dlp output, including live transfer speed and ETA.
- Overall queue ETA estimate.
- Open Folder action and a cleanup toggle in Settings.

All new configuration keys default to backward-compatible values.